### PR TITLE
blender-9999-r1: fix syntax error

### DIFF
--- a/media-gfx/blender/blender-9999-r1.ebuild
+++ b/media-gfx/blender/blender-9999-r1.ebuild
@@ -269,6 +269,7 @@ src_configure() {
 		-DALEMBIC_ABCUTIL_LIBRARY=/usr/lib/static/libAlembicUtil.a
 		-DALEMBIC_ABC_LIBRARY=/usr/lib/static/libAlembicAbc.a
 		-DALEMBIC_OGAWA_LIBRARY=
+	fi
 
 	#make DESTDIR="${D}" install didn't work
 	mycmakeargs="${mycmakeargs}

--- a/media-gfx/openvdb/openvdb-3.1.0-r3.ebuild
+++ b/media-gfx/openvdb/openvdb-3.1.0-r3.ebuild
@@ -20,7 +20,7 @@ IUSE="doc +openvdb-compression X"
 
 DEPEND="
 	sys-libs/zlib
-	>=dev-libs/boost-1.61.0
+	>=dev-libs/boost-1.61.0[python]
 	media-libs/openexr
 	>=dev-cpp/tbb-3.0
 	>=dev-util/cppunit-1.10


### PR DESCRIPTION
Quite obvious, but at least it won't be lost since emerge does complain about unexpected '}'
