### PR TITLE
openvdb-3.1.0-r3: require boost with python support

### DIFF
--- a/media-gfx/openvdb/openvdb-3.1.0-r3.ebuild
+++ b/media-gfx/openvdb/openvdb-3.1.0-r3.ebuild
@@ -20,7 +20,7 @@ IUSE="doc +openvdb-compression X"
 
 DEPEND="
 	sys-libs/zlib
-	>=dev-libs/boost-1.61.0
+	>=dev-libs/boost-1.61.0[python]
 	media-libs/openexr
 	>=dev-cpp/tbb-3.0
 	>=dev-util/cppunit-1.10


### PR DESCRIPTION
python USE flag is optional for dev-libs/boost and compilation will fail if it's not enabled.
