### PR TITLE
Some fixes for blender-9999-r1

### DIFF
--- a/media-gfx/blender/blender-9999-r1.ebuild
+++ b/media-gfx/blender/blender-9999-r1.ebuild
@@ -1,4 +1,4 @@
- 
+
 # Copyright 1999-2014 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Header: /var/cvsroot/gentoo-x86/media-gfx/blender/blender-9999.ebuild,v 1.6 2014/11/30 23:00:00 brothermechanic Exp $
@@ -20,7 +20,7 @@ HOMEPAGE="http://www.blender.org/"
 
 if use pbr; then
 		EGIT_REPO_URI="${BLENDER_PBR_URI}"
-	else	
+	else
 		EGIT_REPO_URI="${BLENDER_REPO_URI}"
 fi
 
@@ -64,7 +64,7 @@ RDEPEND="${PYTHON_DEPS}
 	virtual/jpeg
 	dev-libs/boost[threads(+)]
 	sci-libs/colamd
-	opengl? ( 
+	opengl? (
 		virtual/opengl
 		media-libs/glew
 		virtual/glu
@@ -165,7 +165,7 @@ pkg_setup() {
 			ewarn "'cuda' USE. CUDA will not be compiled until you do so."
 		fi
 	fi
-	
+
 }
 
 src_prepare() {
@@ -175,7 +175,7 @@ src_prepare() {
 		"${FILESDIR}"/sequencer_extra_actions-3.8.patch.bz2 \
 		"${FILESDIR}"/01_include_addon_contrib_in_release \
 		"${FILESDIR}"/050_thumbnailer_use_python3
-		
+
 	epatch_user
 
 	# remove some bundled deps
@@ -258,6 +258,7 @@ src_configure() {
 		-DCUDA_NVCC=/opt/cuda/bin/nvcc"
 	fi
 	if use alembic; then
+		mycmakeargs="${mycmakeargs}
 		-DWITH_ALEMBIC=ON
 		-DALEMBIC_INCLUDE_DIR=/usr/include/Alembic
 		-DALEMBIC_ABCCOREFACTORY=/usr/lib/static/libAlembicAbcCoreFactory.a
@@ -268,7 +269,8 @@ src_configure() {
 		-DALEMBIC_ABCOGAWA_LIBRARY=/usr/lib/static/libAlembicAbcCoreOgawa.a
 		-DALEMBIC_ABCUTIL_LIBRARY=/usr/lib/static/libAlembicUtil.a
 		-DALEMBIC_ABC_LIBRARY=/usr/lib/static/libAlembicAbc.a
-		-DALEMBIC_OGAWA_LIBRARY=
+		-DALEMBIC_OGAWA_LIBRARY="
+	fi
 
 	#make DESTDIR="${D}" install didn't work
 	mycmakeargs="${mycmakeargs}

--- a/media-plugins/blender-BlenRig/blender-BlenRig-9999.ebuild
+++ b/media-plugins/blender-BlenRig/blender-BlenRig-9999.ebuild
@@ -16,7 +16,7 @@ KEYWORDS="~amd64 ~x86"
 IUSE=""
 
 DEPEND=""
-RDEPEND="=media-gfx/blender-9999"
+RDEPEND=">=media-gfx/blender-9999"
 
 src_install() {
 	rm -r "${S}"/.*

--- a/media-plugins/blender-BoolTool/blender-BoolTool-9999.ebuild
+++ b/media-plugins/blender-BoolTool/blender-BoolTool-9999.ebuild
@@ -16,7 +16,7 @@ KEYWORDS="~amd64 ~x86"
 IUSE=""
 
 DEPEND=""
-RDEPEND="=media-gfx/blender-9999"
+RDEPEND=">=media-gfx/blender-9999"
 
 src_install() {
 	if VER="/usr/share/blender/*";then

--- a/media-plugins/blender-MultiEdit/blender-MultiEdit-9999.ebuild
+++ b/media-plugins/blender-MultiEdit/blender-MultiEdit-9999.ebuild
@@ -16,7 +16,7 @@ KEYWORDS="~amd64 ~x86"
 IUSE=""
 
 DEPEND=""
-RDEPEND="=media-gfx/blender-9999"
+RDEPEND=">=media-gfx/blender-9999"
 
 src_install() {
 	if VER="/usr/share/blender/*";then

--- a/media-plugins/blender-YetiTools/blender-YetiTools-9999.ebuild
+++ b/media-plugins/blender-YetiTools/blender-YetiTools-9999.ebuild
@@ -16,7 +16,7 @@ KEYWORDS="~amd64 ~x86"
 IUSE=""
 
 DEPEND=""
-RDEPEND="=media-gfx/blender-9999"
+RDEPEND=">=media-gfx/blender-9999"
 
 src_install() {
 	if VER="/usr/share/blender/*";then

--- a/media-plugins/blender-animation-nodes/blender-animation-nodes-9999.ebuild
+++ b/media-plugins/blender-animation-nodes/blender-animation-nodes-9999.ebuild
@@ -16,7 +16,7 @@ KEYWORDS="~amd64 ~x86"
 IUSE=""
 
 DEPEND=""
-RDEPEND="=media-gfx/blender-9999"
+RDEPEND=">=media-gfx/blender-9999"
 
 src_install() {
 	if VER="/usr/share/blender/*";then

--- a/media-plugins/blender-archimesh/blender-archimesh-9999.ebuild
+++ b/media-plugins/blender-archimesh/blender-archimesh-9999.ebuild
@@ -16,7 +16,7 @@ KEYWORDS="~amd64 ~x86"
 IUSE=""
 
 DEPEND=""
-RDEPEND="=media-gfx/blender-9999"
+RDEPEND=">=media-gfx/blender-9999"
 
 src_install() {
 	mv "${S}"/archimesh/src "${S}"/archimesh/archimesh

--- a/media-plugins/blender-batch-operations/blender-batch-operations-9999.ebuild
+++ b/media-plugins/blender-batch-operations/blender-batch-operations-9999.ebuild
@@ -16,7 +16,7 @@ KEYWORDS="~amd64 ~x86"
 IUSE=""
 
 DEPEND=""
-RDEPEND="=media-gfx/blender-9999"
+RDEPEND=">=media-gfx/blender-9999"
 
 src_install() {
 	rm -r "${S}"/.*

--- a/media-plugins/blender-blam/blender-blam-9999.ebuild
+++ b/media-plugins/blender-blam/blender-blam-9999.ebuild
@@ -16,7 +16,7 @@ KEYWORDS="~amd64 ~x86"
 IUSE=""
 
 DEPEND=""
-RDEPEND="=media-gfx/blender-9999"
+RDEPEND=">=media-gfx/blender-9999"
 
 src_install() {
 	if VER="/usr/share/blender/*";then

--- a/media-plugins/blender-booltron/blender-booltron-9999.ebuild
+++ b/media-plugins/blender-booltron/blender-booltron-9999.ebuild
@@ -16,7 +16,7 @@ KEYWORDS="~amd64 ~x86"
 IUSE=""
 
 DEPEND=""
-RDEPEND="=media-gfx/blender-9999"
+RDEPEND=">=media-gfx/blender-9999"
 
 src_install() {
 	if VER="/usr/share/blender/*";then

--- a/media-plugins/blender-cut-mesh/blender-cut-mesh-9999.ebuild
+++ b/media-plugins/blender-cut-mesh/blender-cut-mesh-9999.ebuild
@@ -16,7 +16,7 @@ KEYWORDS="~amd64 ~x86"
 IUSE=""
 
 DEPEND=""
-RDEPEND="=media-gfx/blender-9999"
+RDEPEND=">=media-gfx/blender-9999"
 
 src_install() {
 	if VER="/usr/share/blender/*";then

--- a/media-plugins/blender-dynamic-slideshow/blender-dynamic-slideshow-9999.ebuild
+++ b/media-plugins/blender-dynamic-slideshow/blender-dynamic-slideshow-9999.ebuild
@@ -16,7 +16,7 @@ KEYWORDS="~amd64 ~x86"
 IUSE=""
 
 DEPEND=""
-RDEPEND="=media-gfx/blender-9999"
+RDEPEND=">=media-gfx/blender-9999"
 
 src_install() {
 	if VER="/usr/share/blender/*";then

--- a/media-plugins/blender-export-selected/blender-export-selected-9999.ebuild
+++ b/media-plugins/blender-export-selected/blender-export-selected-9999.ebuild
@@ -16,7 +16,7 @@ KEYWORDS="~amd64 ~x86"
 IUSE=""
 
 DEPEND=""
-RDEPEND="=media-gfx/blender-9999"
+RDEPEND=">=media-gfx/blender-9999"
 
 src_install() {
 	if VER="/usr/share/blender/*";then

--- a/media-plugins/blender-kinoraw-tools/blender-kinoraw-tools-9999.ebuild
+++ b/media-plugins/blender-kinoraw-tools/blender-kinoraw-tools-9999.ebuild
@@ -16,7 +16,7 @@ KEYWORDS="~amd64 ~x86"
 IUSE=""
 
 DEPEND=""
-RDEPEND="=media-gfx/blender-9999"
+RDEPEND=">=media-gfx/blender-9999"
 
 src_install() {
 	rm -r {*zip,archive,doc,imgs}

--- a/media-plugins/blender-light-studio/blender-light-studio-9999.ebuild
+++ b/media-plugins/blender-light-studio/blender-light-studio-9999.ebuild
@@ -16,7 +16,7 @@ KEYWORDS="~amd64 ~x86"
 IUSE=""
 
 DEPEND=""
-RDEPEND="=media-gfx/blender-9999"
+RDEPEND=">=media-gfx/blender-9999"
 
 src_install() {
 	mv "${S}"/src "${S}"/${PN}

--- a/media-plugins/blender-meltdown/blender-meltdown-9999.ebuild
+++ b/media-plugins/blender-meltdown/blender-meltdown-9999.ebuild
@@ -16,7 +16,7 @@ KEYWORDS="~amd64 ~x86"
 IUSE=""
 
 DEPEND=""
-RDEPEND="=media-gfx/blender-9999"
+RDEPEND=">=media-gfx/blender-9999"
 
 src_install() {
 	rm -r .*

--- a/media-plugins/blender-mira-tools/blender-mira-tools-9999.ebuild
+++ b/media-plugins/blender-mira-tools/blender-mira-tools-9999.ebuild
@@ -16,7 +16,7 @@ KEYWORDS="~amd64 ~x86"
 IUSE=""
 
 DEPEND=""
-RDEPEND="=media-gfx/blender-9999"
+RDEPEND=">=media-gfx/blender-9999"
 
 src_install() {
 	if VER="/usr/share/blender/*";then

--- a/media-plugins/blender-name-panel/blender-name-panel-9999.ebuild
+++ b/media-plugins/blender-name-panel/blender-name-panel-9999.ebuild
@@ -16,7 +16,7 @@ KEYWORDS="~amd64 ~x86"
 IUSE=""
 
 DEPEND=""
-RDEPEND="=media-gfx/blender-9999"
+RDEPEND=">=media-gfx/blender-9999"
 
 src_install() {
 	if VER="/usr/share/blender/*";then

--- a/media-plugins/blender-nodearrange/blender-nodearrange-9999.ebuild
+++ b/media-plugins/blender-nodearrange/blender-nodearrange-9999.ebuild
@@ -16,7 +16,7 @@ KEYWORDS="~amd64 ~x86"
 IUSE=""
 
 DEPEND=""
-RDEPEND="=media-gfx/blender-9999"
+RDEPEND=">=media-gfx/blender-9999"
 
 src_install() {
 	if VER="/usr/share/blender/*";then

--- a/media-plugins/blender-perfect-shape/blender-perfect-shape-9999.ebuild
+++ b/media-plugins/blender-perfect-shape/blender-perfect-shape-9999.ebuild
@@ -16,7 +16,7 @@ KEYWORDS="~amd64 ~x86"
 IUSE=""
 
 DEPEND=""
-RDEPEND="=media-gfx/blender-9999"
+RDEPEND=">=media-gfx/blender-9999"
 
 src_install() {
 	if VER="/usr/share/blender/*";then

--- a/media-plugins/blender-sverchok/blender-sverchok-9999.ebuild
+++ b/media-plugins/blender-sverchok/blender-sverchok-9999.ebuild
@@ -16,7 +16,7 @@ KEYWORDS="~amd64 ~x86"
 IUSE=""
 
 DEPEND=""
-RDEPEND="=media-gfx/blender-9999"
+RDEPEND=">=media-gfx/blender-9999"
 
 src_install() {
 	if VER="/usr/share/blender/*";then

--- a/media-plugins/blender-uvsquares/blender-uvsquares-9999.ebuild
+++ b/media-plugins/blender-uvsquares/blender-uvsquares-9999.ebuild
@@ -16,7 +16,7 @@ KEYWORDS="~amd64 ~x86"
 IUSE=""
 
 DEPEND=""
-RDEPEND="=media-gfx/blender-9999"
+RDEPEND=">=media-gfx/blender-9999"
 
 src_install() {
 	if VER="/usr/share/blender/*";then

--- a/media-plugins/blender-vsfmbundle/blender-vsfmbundle-9999.ebuild
+++ b/media-plugins/blender-vsfmbundle/blender-vsfmbundle-9999.ebuild
@@ -16,7 +16,7 @@ KEYWORDS="~amd64 ~x86"
 IUSE=""
 
 DEPEND=""
-RDEPEND="=media-gfx/blender-9999"
+RDEPEND=">=media-gfx/blender-9999"
 
 src_install() {
 	if VER="/usr/share/blender/*";then

--- a/media-plugins/mitsuba-blender/mitsuba-blender-9999.ebuild
+++ b/media-plugins/mitsuba-blender/mitsuba-blender-9999.ebuild
@@ -16,7 +16,7 @@ KEYWORDS="~amd64 ~x86"
 IUSE=""
 
 DEPEND=""
-RDEPEND="=media-gfx/blender-9999"
+RDEPEND=">=media-gfx/blender-9999"
 
 src_install() {
 	if VER="/usr/share/blender/*";then


### PR DESCRIPTION
- Finishing alembic's  if statement in blender-9999-r1.ebuild
- Replacing =media-gfx/blender-9999 dependency by >=media-gfx/blender-9999
