### PR TITLE
Replaced eselect-opencl dep

### DIFF
--- a/media-gfx/blender/blender-9999.ebuild
+++ b/media-gfx/blender/blender-9999.ebuild
@@ -98,7 +98,7 @@ RDEPEND="${PYTHON_DEPS}
 	lzma? ( app-arch/lzma )
 	lzo? ( dev-libs/lzo )
 	alembic? ( media-gfx/alembic[boost,-hdf] )
-	opencl? ( app-eselect/eselect-opencl )
+	opencl? ( virtual/opencl )
 	opensubdiv? ( media-libs/opensubdiv )
 	nls? ( virtual/libiconv )
 	oidn? ( media-libs/oidn )"


### PR DESCRIPTION
OpenCL support in Gentoo is now being migrated to having all implementations
operate through an ICD loader (dev-libs/ocl-icd or dev-libs/opencl-icd-loader)
installed directly into /usr rather than using eselect-opencl