### PR TITLE
Update EAPI version to 7 in some ebuilds

### DIFF
--- a/dev-util/nvidia-cuda-sdk/nvidia-cuda-sdk-10.1.105.ebuild
+++ b/dev-util/nvidia-cuda-sdk/nvidia-cuda-sdk-10.1.105.ebuild
@@ -1,9 +1,9 @@
 # Copyright 1999-2019 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=6
+EAPI=7
 
-inherit cuda flag-o-matic portability toolchain-funcs unpacker versionator
+inherit cuda flag-o-matic portability toolchain-funcs unpacker
 
 MYD=$(ver_cut 1-2 ${PV})
 DRIVER_PV="418.39"
@@ -27,6 +27,7 @@ RDEPEND="
 		mpi? ( virtual/mpi )
 		)"
 DEPEND="${RDEPEND}"
+BDEPEND="virtual/pkgconfig"
 
 RESTRICT="test"
 
@@ -45,15 +46,10 @@ src_unpack() {
 	unpacker
 }
 
-pkg_setup() {
-	if use cuda || use opencl; then
-		cuda_pkg_setup
-	fi
-}
-
 src_prepare() {
+	cuda_src_prepare
+
 	export RAWLDFLAGS="$(raw-ldflags)"
-#	epatch "${FILESDIR}"/${P}-asneeded.patch
 
 	local file
 	while IFS="" read -d $'\0' -r file; do
@@ -109,12 +105,12 @@ src_install() {
 	if use doc; then
 		ebegin "Installing docs ..."
 			while IFS="" read -d $'\0' -r f; do
-				treecopy "${f}" "${ED%/}"/usr/share/doc/${PF}/
+				treecopy "${f}" "${ED}"/usr/share/doc/${PF}/
 			done < <(find -type f \( -name 'readme.txt' -o -name '*.pdf' \) -print0)
 
 			while IFS="" read -d $'\0' -r f; do
-				docompress -x "${f#${ED%/}}"
-			done < <(find "${ED%/}"/usr/share/doc/${PF}/ -type f -name 'readme.txt' -print0)
+				docompress -x "${f#${ED}}"
+			done < <(find "${ED}"/usr/share/doc/${PF}/ -type f -name 'readme.txt' -print0)
 		eend
 	fi
 

--- a/dev-util/nvidia-cuda-sdk/nvidia-cuda-sdk-10.1.168.ebuild
+++ b/dev-util/nvidia-cuda-sdk/nvidia-cuda-sdk-10.1.168.ebuild
@@ -1,9 +1,9 @@
 # Copyright 1999-2019 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=6
+EAPI=7
 
-inherit cuda flag-o-matic portability toolchain-funcs unpacker versionator
+inherit cuda flag-o-matic portability toolchain-funcs unpacker
 
 MYD=$(ver_cut 1-2 ${PV})
 DRIVER_PV="418.67"
@@ -26,6 +26,7 @@ RDEPEND="
 		mpi? ( virtual/mpi )
 		)"
 DEPEND="${RDEPEND}"
+BDEPEND="virtual/pkgconfig"
 
 RESTRICT="test"
 
@@ -44,15 +45,10 @@ src_unpack() {
 	unpacker
 }
 
-pkg_setup() {
-	if use cuda || use opencl; then
-		cuda_pkg_setup
-	fi
-}
-
 src_prepare() {
+	cuda_src_prepare
+
 	export RAWLDFLAGS="$(raw-ldflags)"
-#	epatch "${FILESDIR}"/${P}-asneeded.patch
 
 	local file
 	while IFS="" read -d $'\0' -r file; do
@@ -108,12 +104,12 @@ src_install() {
 	if use doc; then
 		ebegin "Installing docs ..."
 			while IFS="" read -d $'\0' -r f; do
-				treecopy "${f}" "${ED%/}"/usr/share/doc/${PF}/
+				treecopy "${f}" "${ED}"/usr/share/doc/${PF}/
 			done < <(find -type f \( -name 'readme.txt' -o -name '*.pdf' \) -print0)
 
 			while IFS="" read -d $'\0' -r f; do
-				docompress -x "${f#${ED%/}}"
-			done < <(find "${ED%/}"/usr/share/doc/${PF}/ -type f -name 'readme.txt' -print0)
+				docompress -x "${f#${ED}}"
+			done < <(find "${ED}"/usr/share/doc/${PF}/ -type f -name 'readme.txt' -print0)
 		eend
 	fi
 

--- a/media-makehuman/mhx2-makehuman-exchange/mhx2-makehuman-exchange-9999.ebuild
+++ b/media-makehuman/mhx2-makehuman-exchange/mhx2-makehuman-exchange-9999.ebuild
@@ -1,7 +1,7 @@
 # Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=6
+EAPI=7
 
 inherit mercurial git-r3
 

--- a/media-plugins/refocus-it/refocus-it-2.0.0.ebuild
+++ b/media-plugins/refocus-it/refocus-it-2.0.0.ebuild
@@ -2,6 +2,8 @@
 # Distributed under the terms of the GNU General Public License v2
 # $Header: $
 
+EAPI=7
+
 inherit eutils
 
 DESCRIPTION="Iterative refocus GIMP plug-in."

--- a/x11-misc/xbindkeys-config/xbindkeys-config-0.1.3.ebuild
+++ b/x11-misc/xbindkeys-config/xbindkeys-config-0.1.3.ebuild
@@ -1,7 +1,7 @@
 # Copyright 1999-2012 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=4
+EAPI=7
 inherit eutils toolchain-funcs
 
 DEB_PATCH="${PN}_${PV}-2.diff"


### PR DESCRIPTION
I applied the [patch](https://github.com/gentoo/gentoo/commit/e9bb2213bb895e4a26c3e2a5a972c255d0d0af24) to `dev-util/nvidia-cuda-sdk`; other 3 ebuilds didn't seem to be in need of any change except simply bumbing up (or adding) the `EAPI=...` line.

Closes #61 