### PR TITLE
PureRef: add RESTRICT="strip"

### DIFF
--- a/media-gfx/PureRef/PureRef-1.11.1.ebuild
+++ b/media-gfx/PureRef/PureRef-1.11.1.ebuild
@@ -8,7 +8,7 @@ inherit eutils
 DESCRIPTION="PureRef - Reference Image Viewer"
 HOMEPAGE="https://www.pureref.com"
 SRC_URI="${P}_x64.deb"
-RESTRICT="fetch"
+RESTRICT="fetch strip"
 LICENSE=""
 SLOT="0"
 KEYWORDS="~amd64 ~x86"


### PR DESCRIPTION
Without this, attempting to run the installed PureRef appimage will produce this error:

```
This doesn't look like a squashfs image.

Cannot mount AppImage, please check your FUSE setup.
You might still be able to extract the contents of this AppImage 
if you run it with the --appimage-extract option. 
See https://github.com/AppImage/AppImageKit/wiki/FUSE 
for more information
open dir error: No such file or directory
```

It seems that strip breaks the AppImage binary. 

After this change, PureRef starts as expected.