### PR TITLE
Update emscripten-3.1.67.ebuild

### DIFF
--- a/dev-util/emscripten/emscripten-3.1.67.ebuild
+++ b/dev-util/emscripten/emscripten-3.1.67.ebuild
@@ -14,16 +14,16 @@ SRC_URI="https://github.com/emscripten-core/emscripten/archive/${PV}.tar.gz -> $
 LICENSE="MIT"
 SLOT="0"
 KEYWORDS="~amd64"
-IUSE="java nodejs python"
+IUSE="java python llvm_targets_WebAssembly"
 
 REQUIRED_USE="llvm_targets_WebAssembly"
 
 RDEPEND="
 	${PYTHON_DEPS}
 	dev-util/binaryen
-    sys-apps/which
-    python? ( dev-lang/python )
-    nodejs? ( net-libs/nodejs )
+        net-libs/nodejs[npm]
+	sys-apps/which
+	python? ( dev-lang/python )
 	java? ( virtual/jre )
 "
 BDEPEND="
@@ -32,10 +32,10 @@ BDEPEND="
      sys-devel/llvm:${LLVM_SLOT}=
    ')
 	dev-build/cmake
-    dev-libs/libxml2
-    dev-vcs/git
-    dev-build/ninja
-    java? ( virtual/jdk )
+	dev-libs/libxml2
+	dev-vcs/git
+	dev-build/ninja
+	java? ( virtual/jdk )
 "
 
 RESTRICT="mirror"


### PR DESCRIPTION
Few needed fixes to be able to emerge

- `llvm_targets_WebAssemply` needed to be in `IUSE`
- `nodejs` is needed during build time even if the use flag is off
  - npm is needed

My changes may not be good enough though. Thanks!