### PR TITLE
PyQt -> pyqt

### DIFF
--- a/media-gfx/makehuman/makehuman-9999.ebuild
+++ b/media-gfx/makehuman/makehuman-9999.ebuild
@@ -21,7 +21,7 @@ REQUIRED_USE="${PYTHON_REQUIRED_USE}"
 RDEPEND="${PYTHON_DEPS}
 	dev-python/numpy
 	dev-python/pyopengl
-	dev-python/PyQt5
+	dev-python/pyqt5
 	dev-qt/qtsvg"
 
 DEPEND="${RDEPEND}"


### PR DESCRIPTION
PyQt5 was renamed to pyqt5

https://gitweb.gentoo.org/repo/gentoo.git/commit/?id=37d48fa129706f33aff087d4d599a2b16114ef14