### PR TITLE
🩹 Fix Audaspace version for Blender 4.2

### DIFF
--- a/media-gfx/blender/blender-9999.ebuild
+++ b/media-gfx/blender/blender-9999.ebuild
@@ -35,7 +35,14 @@ else
 fi
 
 [[ "4.0 3.6" =~ "${MY_PV}"  ]] && OSL_PV="13" || OSL_PV="14"
-[[ "4.0 3.6 4.2 4.3 4.4" =~ "${MY_PV}" ]] && AUD_PV="6" || AUD_PV="7"
+
+if [[ "4.0 3.6 4.2" =~ "${MY_PV}" ]]; then
+	AUD_PV="5"
+elif [[ "4.3 4.4" =~ "${MY_PV}" ]]; then
+	AUD_PV="6"
+else
+	AUD_PV="7"
+fi
 
 SLOT="$MY_PV"
 LICENSE="|| ( GPL-3 BL )"


### PR DESCRIPTION
_Hello,_

**Blender 4.2.14** build fails with **Audaspace 1.6.0**.
It requires **1.5.0** instead.

_Best regards!_